### PR TITLE
Fix datetime formatting

### DIFF
--- a/themes/powerline-2column.theme.bash
+++ b/themes/powerline-2column.theme.bash
@@ -205,7 +205,7 @@ _get_battery_info () {
 _date ()
 {
   local date_now
-  date_now="$(date '+%H:%M%P')"
+  date_now="$(date '+%I:%M%p')"
   let ps1r_cnt+=${#date_now}
   date_str="${PS_White}${On_Black}${PS_Black}${PS_On_White} ${date_now} ${PS_Color_Off}"
 


### PR DESCRIPTION
I fixed the datetime formatting of the powerline-2column.theme.bash file, see screenshots below.
before:
![Screenshot 2023-06-24 at 00 27 06](https://github.com/victorbrca/bash-config/assets/66885075/25d4e1cc-8d9d-4ddc-9883-b1acfa99d882)
after:
![Screenshot 2023-06-24 at 00 26 21](https://github.com/victorbrca/bash-config/assets/66885075/b8a8742e-d50c-4e0f-967d-1457e5ec515f)
